### PR TITLE
Fix MariaDB doesn't allow to ''

### DIFF
--- a/server/lib/NicToolServer/Zone/Record.pm
+++ b/server/lib/NicToolServer/Zone/Record.pm
@@ -142,6 +142,14 @@ sub edit_zone_record {
             $sql .= "type_id = ?";
             push @values, $self->get_record_type({ type=> $data->{$c} });
         }
+        elsif ( $c eq 'timestamp' || $c eq 'weight' || $c eq 'priority' ) {
+            if( ! $data->{$c}) {
+                $sql =~ s/,$//;
+                next;
+            }
+            $sql .= "$c = ?";
+            push @values, $data->{$c};
+        }
         else {
             $sql .= "$c = ?";
             push @values, $data->{$c};


### PR DESCRIPTION
Fix for MariaDB which no longer permits '' for a INT or TIMESTAMP field, so if no value is provided, then simply omit the field and let the default column value apply.

Fixes #

Changes proposed in this pull request:
Don't use '' to in SQL queries for INT/TIMESTAMP fields.

Checklist:
- [ ] docs updated
- [ ] tests updated
